### PR TITLE
Spread relay and haproxy pods evenly between nodes

### DIFF
--- a/haproxy.tf
+++ b/haproxy.tf
@@ -80,6 +80,16 @@ EOT
 
   dns_annotations_yaml = var.auto_create_dns ? "" : "external-dns.alpha.kubernetes.io/hostname: \"\""
 
+  topology_spread_yaml = var.topology_spread_enabled ? join("\n", [
+    "topologySpreadConstraints:",
+    "  - maxSkew: 1",
+    "    topologyKey: kubernetes.io/hostname",
+    "    whenUnsatisfiable: ScheduleAnyway",
+    "    labelSelector:",
+    "      matchLabels:",
+    "        app.kubernetes.io/name: haproxy"
+  ]) : ""
+
   node_selector_yaml = (var.node_selector_enabled && var.node_selector != "") ? join("\n", [
     "nodeSelector:",
     "  \"node_pool\": \"${var.node_selector}\"",
@@ -127,6 +137,7 @@ ${local.extra_domains_yaml}
 ${length(var.extra_domains) > 0 ? "  extraTls:" : ""}
 ${local.tls_yaml}
 ${local.node_selector_yaml}
+${local.topology_spread_yaml}
 EOF
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -115,6 +115,18 @@ resource "kubernetes_stateful_set_v1" "relay" {
           image_pull_policy = "Always"
         }
 
+        dynamic "topology_spread_constraint" {
+          for_each = var.topology_spread_enabled ? [1] : []
+          content {
+            max_skew           = 1
+            topology_key       = "kubernetes.io/hostname"
+            when_unsatisfiable = "ScheduleAnyway"
+            label_selector {
+              match_labels = local.commonLabels
+            }
+          }
+        }
+
         affinity {
           dynamic "pod_affinity" {
             for_each = try(var.node_affinity_config, [])

--- a/variables.tf
+++ b/variables.tf
@@ -137,6 +137,12 @@ variable "max_unavailable" {
   default     = "1"
 }
 
+variable "topology_spread_enabled" {
+  description = "Enable topology spread constraints to distribute pods evenly across nodes"
+  type        = bool
+  default     = true
+}
+
 variable "auto_create_tls" {
   description = "Flag to enable cert-manager annotations to auto generate tls certificates"
   type        = bool


### PR DESCRIPTION
Fix this story: https://github.com/ObolNetwork/obol-infrastructure/pull/2268

As part of a cost-reduction initiative, we need to downsize the GKE relay node group to a smaller instance type.

category: improvement
