### PR TITLE
fix: pin GitHub Actions to SHA for supply chain security

### DIFF
--- a/.github/workflows/add-issue-to-project.yaml
+++ b/.github/workflows/add-issue-to-project.yaml
@@ -15,7 +15,7 @@ jobs:
     # Steps
     steps:
       - name: Add Issue To Project
-        uses: actions/add-to-project@v1.0.2
+        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           # URL of the project to add issues to
           project-url: https://github.com/orgs/ObolNetwork/projects/7

--- a/.github/workflows/label-issues.yaml
+++ b/.github/workflows/label-issues.yaml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             github.rest.issues.addLabels({

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -5,12 +5,12 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ github.event.pull_request.head.ref }}
 
     - name: Render terraform docs inside the MODULE.md and push changes back to PR branch
-      uses: Dirrk/terraform-docs@v1.0.8
+      uses: Dirrk/terraform-docs@26b70436ceceba0a62c6b083d67c0796ea89bdeb # v1.0.8
       with:
         tf_docs_working_dir: .
         tf_docs_output_file: MODULE.md

--- a/.github/workflows/terraform-lint.yaml
+++ b/.github/workflows/terraform-lint.yaml
@@ -9,6 +9,6 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@main
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # main
     - name: Lint Terraform
-      uses: actionshub/terraform-lint@main
+      uses: actionshub/terraform-lint@9e854ecdc0cedda954adfffccced9f71dc12fda0 # main


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions `uses:` references to commit SHAs for supply chain security
- Original version tags preserved as inline comments for maintainability
- Mitigates supply chain attacks where a compromised tag could inject malicious code (ref: Trivy incident March 2026)

## Changes
- All `uses: owner/action@tag` → `uses: owner/action@SHA # tag`
- No version changes, only pinning format

## Test plan
- [x] Verify CI workflows run successfully
- [x] Confirm no action versions changed, only pinning format